### PR TITLE
Pin pip version to 9 to avoid upgrade to pip 10 beta

### DIFF
--- a/pre-requirements.txt
+++ b/pre-requirements.txt
@@ -1,1 +1,2 @@
 setuptools==15.2
+pip==9.0.3


### PR DESCRIPTION
This PR pins the version of pip used in the ginkgo branch to 9. Currently for some reason pip 10 beta seems to be installed in the xqueue virtualenv which breaks the pika install.