### PR TITLE
Cleanly close AMQP Channels

### DIFF
--- a/queue/producer.py
+++ b/queue/producer.py
@@ -3,6 +3,7 @@ import time
 from django.conf import settings
 
 import pika
+from contextlib import closing
 
 
 MAX_RETRIES = 5
@@ -42,17 +43,18 @@ def push_to_queue(queue_name, qitem=None):
         else:
             break
 
-    channel = connection.channel()
+    with closing(connection):
+        channel = connection.channel()
 
-    queue = channel.queue_declare(queue=queue_name, durable=True)
+        with closing(channel):
+            queue = channel.queue_declare(queue=queue_name, durable=True)
 
-    if qitem is not None:
-        channel.basic_publish(exchange='',
-                              routing_key=queue_name,
-                              body=qitem,
-                              properties=pika.BasicProperties(delivery_mode=2))
+            if qitem is not None:
+                channel.basic_publish(exchange='',
+                                      routing_key=queue_name,
+                                      body=qitem,
+                                      properties=pika.BasicProperties(delivery_mode=2))
 
-    connection.close()
     return queue.method.message_count
 
 


### PR DESCRIPTION
This backports the fixes from OC-3533 to ginkgo.
We were seeing excessive logging in rabbitmq due to AMQP channels closing prematurely, which caused disks to fill. This PR cleanly closes the channel before terminating the connection

**JIRA tickets**: backport for OC-4568, first fix on master in OC-3533

**Merge deadline**: "None"

**Testing instructions**:

1. Checkout branch on an AppServer utilizing xqueue.
2. Restart xqueue
3. Check RabbitMQ server to see that warning messages from that host stop appearing

**Reviewers**
- [ ] (TBD)